### PR TITLE
feat(cleaning): handle missing values and remove outliers

### DIFF
--- a/notebooks/notebook.ipynb
+++ b/notebooks/notebook.ipynb
@@ -393,23 +393,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Correlation heatmap (numeric features only)\n",
-    "# TODO: Uncomment when ready\n",
-    "\n",
-    "# numeric_cols = train_df.select_dtypes(include=[np.number]).columns\n",
-    "# fig, ax = plt.subplots(figsize=(12, 10))\n",
-    "# sns.heatmap(train_df[numeric_cols].corr(), annot=True, fmt=\".2f\", cmap=\"coolwarm\", ax=ax)\n",
-    "# ax.set_title(\"Correlation Matrix\")\n",
-    "# plt.tight_layout()\n",
-    "# plt.show()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -422,16 +405,173 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: Handle missing values\n",
-    "# Examples:\n",
-    "# train_df[\"column\"].fillna(train_df[\"column\"].median(), inplace=True)\n",
-    "# train_df.dropna(subset=[\"important_column\"], inplace=True)\n",
+    "# Remove 2 GrLivArea outliers identified in EDA (>4000 sqft, <$300k)\n",
+    "# WHY: These are likely partial sales that would distort the model\n",
+    "outlier_idx = train_df[(train_df[\"GrLivArea\"] > 4000) & (train_df[TARGET_COL] < 300000)].index\n",
+    "print(f\"Removing {len(outlier_idx)} outliers (Ids: {train_df.loc[outlier_idx, 'Id'].tolist()})\")\n",
+    "train_df = train_df.drop(outlier_idx).reset_index(drop=True)\n",
+    "print(f\"Train shape after outlier removal: {train_df.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.1 Handle \"Feature Absent\" NAs\n",
     "\n",
-    "# TODO: Fix data types\n",
-    "# train_df[\"column\"] = train_df[\"column\"].astype(\"category\")\n",
+    "Per `data_description.txt`, NA in many columns means the feature doesn't exist (no pool, no garage, no basement, etc.). These are not truly missing — fill with `\"None\"` (categorical) or `0` (numeric)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Columns where NA means \"feature absent\" — fill with \"None\" or 0\n",
+    "# WHY: data_description.txt documents NA as a valid category (e.g., \"NA = No Pool\")\n",
     "\n",
-    "# TODO: Remove duplicates if needed\n",
-    "# train_df.drop_duplicates(inplace=True)"
+    "absent_cat_cols = [\n",
+    "    \"PoolQC\",\n",
+    "    \"MiscFeature\",\n",
+    "    \"Alley\",\n",
+    "    \"Fence\",\n",
+    "    \"FireplaceQu\",\n",
+    "    \"GarageType\",\n",
+    "    \"GarageFinish\",\n",
+    "    \"GarageQual\",\n",
+    "    \"GarageCond\",\n",
+    "    \"BsmtQual\",\n",
+    "    \"BsmtCond\",\n",
+    "    \"BsmtExposure\",\n",
+    "    \"BsmtFinType1\",\n",
+    "    \"BsmtFinType2\",\n",
+    "    \"MasVnrType\",\n",
+    "]\n",
+    "absent_num_cols = [\n",
+    "    \"GarageYrBlt\",\n",
+    "    \"GarageArea\",\n",
+    "    \"GarageCars\",\n",
+    "    \"BsmtFinSF1\",\n",
+    "    \"BsmtFinSF2\",\n",
+    "    \"BsmtUnfSF\",\n",
+    "    \"TotalBsmtSF\",\n",
+    "    \"BsmtFullBath\",\n",
+    "    \"BsmtHalfBath\",\n",
+    "    \"MasVnrArea\",\n",
+    "]\n",
+    "\n",
+    "for df in [train_df, test_df]:\n",
+    "    for col in absent_cat_cols:\n",
+    "        df[col] = df[col].fillna(\"None\")\n",
+    "    for col in absent_num_cols:\n",
+    "        df[col] = df[col].fillna(0)\n",
+    "\n",
+    "print(\"Filled 'feature absent' NAs:\")\n",
+    "print(f\"  Categorical ({len(absent_cat_cols)} cols): → 'None'\")\n",
+    "print(f\"  Numeric ({len(absent_num_cols)} cols): → 0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.2 Impute LotFrontage by Neighborhood Median\n",
+    "\n",
+    "WHY: Lots in the same neighborhood tend to have similar frontage. Neighborhood median is a better imputation than global median."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Impute LotFrontage — fit on train, apply to both\n",
+    "# WHY: No data leakage — stats computed on train only\n",
+    "lot_frontage_by_neighborhood = train_df.groupby(\"Neighborhood\")[\"LotFrontage\"].median()\n",
+    "\n",
+    "for df in [train_df, test_df]:\n",
+    "    for idx in df[df[\"LotFrontage\"].isnull()].index:\n",
+    "        neighborhood = df.loc[idx, \"Neighborhood\"]\n",
+    "        median_val = lot_frontage_by_neighborhood.get(neighborhood, train_df[\"LotFrontage\"].median())\n",
+    "        df.loc[idx, \"LotFrontage\"] = median_val\n",
+    "\n",
+    "print(\"LotFrontage imputed by neighborhood median (fitted on train)\")\n",
+    "print(f\"  Train missing: {train_df['LotFrontage'].isnull().sum()}\")\n",
+    "print(f\"  Test missing:  {test_df['LotFrontage'].isnull().sum()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.3 Impute Remaining Missing Values\n",
+    "\n",
+    "Strategy: mode for categorical, median for numeric. All stats fitted on train only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Impute remaining missing values — fit on train, apply to both\n",
+    "# WHY: Some columns have a few remaining NAs (Electrical in train, MSZoning/Functional/etc. in test)\n",
+    "\n",
+    "# Compute fill values from train\n",
+    "cat_fill = {}\n",
+    "num_fill = {}\n",
+    "\n",
+    "for col in train_df.columns:\n",
+    "    if col in [\"Id\", TARGET_COL]:\n",
+    "        continue\n",
+    "    if train_df[col].dtype.kind in (\"f\", \"i\", \"u\"):  # float, int, unsigned int\n",
+    "        num_fill[col] = train_df[col].median()\n",
+    "    else:\n",
+    "        cat_fill[col] = train_df[col].mode().iloc[0] if not train_df[col].mode().empty else \"None\"\n",
+    "\n",
+    "# Apply to both datasets\n",
+    "for df in [train_df, test_df]:\n",
+    "    for col, val in cat_fill.items():\n",
+    "        if col in df.columns:\n",
+    "            df[col] = df[col].fillna(val)\n",
+    "    for col, val in num_fill.items():\n",
+    "        if col in df.columns:\n",
+    "            df[col] = df[col].fillna(val)\n",
+    "\n",
+    "print(\"Remaining NAs imputed (mode for categorical, median for numeric)\")\n",
+    "print(f\"  Train total missing: {train_df.drop(columns=['Id', TARGET_COL]).isnull().sum().sum()}\")\n",
+    "print(f\"  Test total missing:  {test_df.drop(columns=['Id']).isnull().sum().sum()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.4 Verification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Final verification — zero missing values in both datasets\n",
+    "train_missing_final = train_df.drop(columns=[\"Id\", TARGET_COL]).isnull().sum().sum()\n",
+    "test_missing_final = test_df.drop(columns=[\"Id\"]).isnull().sum().sum()\n",
+    "\n",
+    "print(f\"Train missing values: {train_missing_final}\")\n",
+    "print(f\"Test missing values:  {test_missing_final}\")\n",
+    "assert train_missing_final == 0, \"Train still has missing values!\"\n",
+    "assert test_missing_final == 0, \"Test still has missing values!\"\n",
+    "print(\"\\n✓ No missing values remain in train or test.\")\n",
+    "\n",
+    "print(\"\\nFinal shapes:\")\n",
+    "print(f\"  Train: {train_df.shape}\")\n",
+    "print(f\"  Test:  {test_df.shape}\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- Remove 2 GrLivArea outliers identified in EDA (>4000 sqft with SalePrice < $300k)
- Fill "feature absent" NAs with `"None"` (categorical) and `0` (numeric) for 25 columns where NA means the feature doesn't exist (no pool, no garage, no basement, etc.)
- Impute LotFrontage (17.7% missing) by neighborhood median — fitted on train only
- Impute remaining missing values: mode for categorical, median for numeric — all fitted on train
- Assert zero missing values in both train and test datasets

**No data leakage:** all statistics (medians, modes) computed on train only, then applied to both datasets.

## Checklist

- [x] Raw data untouched (`data/raw/` not modified)
- [x] No data leakage (fit on train, transform both)
- [x] Each imputation strategy documented with WHY
- [x] Verification cell: 0 missing in train and test
- [x] `make lint` passes
- [x] Kernel Restart & Run All succeeds

Closes #2